### PR TITLE
fix indices/1 on empty string

### DIFF
--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -258,11 +258,13 @@ pub(crate) fn group_by(context: Value) -> Result<Value> {
 
 fn indices(context: Value, s: Value) -> Result<Value> {
     let ret = match (context, s) {
-        (Value::String(lhs), Value::String(rhs)) => Array::from_vec(
+        (Value::String(lhs), Value::String(rhs)) => Array::from_vec(if rhs.is_empty() {
+            vec![]
+        } else {
             lhs.match_indices(rhs.as_ref())
                 .map(|(pos, _)| Value::Number(pos.into()))
-                .collect(),
-        )
+                .collect()
+        })
         .into(),
         (Value::Array(lhs), Value::Array(rhs)) => Array::from_vec(if rhs.is_empty() {
             vec![]

--- a/tests/from_manual/functions.rs
+++ b/tests/from_manual/functions.rs
@@ -940,6 +940,19 @@ test!(
 test!(
     indices2,
     r#"
+    indices("")
+    "#,
+    r#"
+    "abcde"
+    "#,
+    r#"
+    []
+    "#
+);
+
+test!(
+    indices3,
+    r#"
     indices(1)
     "#,
     r#"
@@ -951,7 +964,7 @@ test!(
 );
 
 test!(
-    indices3,
+    indices4,
     r#"
     indices([1,2])
     "#,
@@ -960,6 +973,19 @@ test!(
     "#,
     r#"
     [1,8]
+    "#
+);
+
+test!(
+    indices5,
+    r#"
+    indices([])
+    "#,
+    r#"
+    [0,1,2,3]
+    "#,
+    r#"
+    []
     "#
 );
 


### PR DESCRIPTION
The `indices/1` filter with empty string argument should return an empty array. This PR fixes this behavior.
```sh
❯ jq -n '"abc" | indices("")'    
[]

❯ xq --version               
xq 0.1.7-f478cd1ff8459f55fd219c1ca5f9ee84ef459b8e

❯ xq -n '"abc" | indices("")'
[
  0,
  1,
  2,
  3
]
```