### PR TITLE
fix panic on slice when start is greater than end

### DIFF
--- a/src/intrinsic/index.rs
+++ b/src/intrinsic/index.rs
@@ -133,7 +133,7 @@ pub(crate) fn calculate_slice_index(
         Bound::Excluded(i) => i,
         Bound::Unbounded => length,
     };
-    Ok(start..end)
+    Ok(if start <= end { start..end } else { 0..0 })
 }
 
 pub(crate) fn slice(

--- a/tests/from_manual/basic_filters.rs
+++ b/tests/from_manual/basic_filters.rs
@@ -183,6 +183,32 @@ test!(
 );
 
 test!(
+    array_string_slice5,
+    r#"
+    .[2:2]
+    "#,
+    r#"
+    ["a","b","c","d","e"]
+    "#,
+    r#"
+    []
+    "#
+);
+
+test!(
+    array_string_slice6,
+    r#"
+    .[3:2]
+    "#,
+    r#"
+    ["a","b","c","d","e"]
+    "#,
+    r#"
+    []
+    "#
+);
+
+test!(
     array_object_value_iterator1,
     r#"
     .[]


### PR DESCRIPTION

This PR fixes slicing when start is greater than end.
```sh
❯ jq -n '[1,2,3] | .[2:1]'
[]

❯ xq -n '[1,2,3] | .[2:1]'
thread 'main' panicked at 'slice index starts at 2 but ends at 1', src/intrinsic/index.rs:177:15
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```