### PR TITLE
Support trailing comma in object literal

### DIFF
--- a/src/lang/ast.rs
+++ b/src/lang/ast.rs
@@ -133,7 +133,7 @@ pub enum Term {
     Query(Box<Query>),
     /// `('+' | '-') <term>`
     Unary(UnaryOp, Box<Term>),
-    /// `'{' (<ident> | <variable> | <keyword> | <string> | '(' <query> ')') (':' <term> ('|' <term>)*)? (',' ....)* '}'`
+    /// `'{' (<ident> | <variable> | <keyword> | <string> | '(' <query> ')') (':' <term> ('|' <term>)*)? (',' ....)* ','? '}'`
     Object(Vec<(Query, Option<Query>)>),
     /// `'[' (<query>)? ']'`
     Array(Option<Box<Query>>),

--- a/src/lang/parser.rs
+++ b/src/lang/parser.rs
@@ -282,7 +282,10 @@ fn constant_object(input: &str) -> ParseResult<ConstantObject> {
     delimited(
         terminated(char('{'), multispace0),
         map(separated_list0(ws(char(',')), entry), ConstantObject),
-        preceded(multispace0, char('}')),
+        preceded(
+            multispace0,
+            preceded(opt(terminated(char(','), multispace0)), char('}')),
+        ),
     )(input)
 }
 
@@ -402,7 +405,10 @@ fn term(input: &str) -> ParseResult<Term> {
                 delimited(
                     terminated(char('{'), multispace0),
                     separated_list0(char(','), ws(object_term_entry)),
-                    preceded(multispace0, char('}')),
+                    preceded(
+                        multispace0,
+                        preceded(opt(terminated(char(','), multispace0)), char('}')),
+                    ),
                 ),
                 Term::Object,
             ),

--- a/tests/from_manual/types_and_values.rs
+++ b/tests/from_manual/types_and_values.rs
@@ -68,6 +68,19 @@ test!(
 );
 
 test!(
+    object4,
+    r#"
+    {foo,bar,}
+    "#,
+    r#"
+    {"foo":1,"bar":2,"baz":3}
+    "#,
+    r#"
+    {"foo":1,"bar":2}
+    "#
+);
+
+test!(
     recursive_descent,
     r#"
     ..|.a?


### PR DESCRIPTION
This PR add support for trailing comma in object literal.
```sh
 $ jq '{foo,bar,}' <<< '{"foo": 1, "bar": 2, "baz": 3}'
{
  "foo": 1,
  "bar": 2
}
 $ jq -n 'module { x: 1, }; .'
null
```