### PR TITLE
Fix multiplying string

### DIFF
--- a/tests/from_manual/arithmetic.rs
+++ b/tests/from_manual/arithmetic.rs
@@ -143,3 +143,23 @@ test!(
     -1
     "#
 );
+
+test!(
+    multiply_string,
+    r#"
+    (0,3,-3,nan) * "abc", "abc" * (0,3,-3,nan)
+    "#,
+    r#"
+    "abc"
+    "#,
+    r#"
+    null
+    "abcabcabc"
+    null
+    null
+    null
+    "abcabcabc"
+    null
+    null
+    "#
+);


### PR DESCRIPTION
This PR fixes multiplying string with negative number or NaN. Also implements `{num} * {str}` case.
```sh
❯ jq -n '(0,3,-3,nan) * "abc"'
null
"abcabcabc"
null
null
```