### PR TITLE
Fix contains filter on booleans to be jq compatible

### DIFF
--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -171,7 +171,7 @@ fn contains(context: Value, element: Value) -> Result<Value> {
     fn contains_rec(lhs: &Value, rhs: &Value) -> Result<bool> {
         Ok(match (lhs, rhs) {
             (Value::Null, Value::Null) => true,
-            (Value::Boolean(lhs), Value::Boolean(rhs)) => lhs == rhs,
+            (Value::Boolean(lhs), Value::Boolean(rhs)) if lhs == rhs => true,
             (Value::Number(lhs), Value::Number(rhs)) => lhs == rhs, // TODO: nan handling in JQ semantics...
             (Value::String(lhs), Value::String(rhs)) => lhs.contains(rhs.as_ref()),
             (Value::Array(lhs), Value::Array(rhs)) => rhs

--- a/tests/hand_written/mod.rs
+++ b/tests/hand_written/mod.rs
@@ -99,6 +99,20 @@ test!(
 );
 
 test!(
+    contains_on_boolean,
+    r#"
+    .[] | [contains(.,not)?]
+    "#,
+    r#"
+    [false,true]
+    "#,
+    r#"
+    [true]
+    [true]
+    "#
+);
+
+test!(
     indices_with_empty_array,
     r#"
     indices([])


### PR DESCRIPTION
This PR fixes `contains/1` filter to be more jq compatible. This filter on booleans emits error if the values are different.
```sh
❯ jq -c '.[] | [contains(.,not)?]' <<< '[false,true]'
[true]
[true]

❯ jq -n 'true | contains(false)'
jq: error (at <unknown>): boolean (true) and boolean (false) cannot have their containment checked

❯ xq -c '.[] | [contains(.,not)?]' <<< '[false,true]'
[true,false]
[true,false]

❯ xq --version
xq 0.2.2-df131ce732645c4c89d9b393404c8fd0be2f08e5
```