### PR TITLE
Fix indices/1 filter against null

### DIFF
--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -258,6 +258,7 @@ pub(crate) fn group_by(context: Value) -> Result<Value> {
 
 fn indices(context: Value, s: Value) -> Result<Value> {
     let ret = match (context, s) {
+        (Value::Null, _) => Value::Null,
         (Value::String(lhs), Value::String(rhs)) => Array::from_vec(if rhs.is_empty() {
             vec![]
         } else {

--- a/tests/from_manual/functions.rs
+++ b/tests/from_manual/functions.rs
@@ -940,19 +940,6 @@ test!(
 test!(
     indices2,
     r#"
-    indices("")
-    "#,
-    r#"
-    "abcde"
-    "#,
-    r#"
-    []
-    "#
-);
-
-test!(
-    indices3,
-    r#"
     indices(1)
     "#,
     r#"
@@ -964,7 +951,7 @@ test!(
 );
 
 test!(
-    indices4,
+    indices3,
     r#"
     indices([1,2])
     "#,
@@ -973,19 +960,6 @@ test!(
     "#,
     r#"
     [1,8]
-    "#
-);
-
-test!(
-    indices5,
-    r#"
-    indices([])
-    "#,
-    r#"
-    [0,1,2,3]
-    "#,
-    r#"
-    []
     "#
 );
 

--- a/tests/hand_written/mod.rs
+++ b/tests/hand_written/mod.rs
@@ -139,6 +139,19 @@ test!(
 );
 
 test!(
+    indices_against_null,
+    r#"
+    indices(0)
+    "#,
+    r#"
+    null
+    "#,
+    r#"
+    null
+    "#
+);
+
+test!(
     limit_infinite_stream,
     r#"
     limit(3; repeat(0))

--- a/tests/hand_written/mod.rs
+++ b/tests/hand_written/mod.rs
@@ -113,6 +113,19 @@ test!(
 );
 
 test!(
+    indices_with_empty_string,
+    r#"
+    indices("")
+    "#,
+    r#"
+    "abcde"
+    "#,
+    r#"
+    []
+    "#
+);
+
+test!(
     indices_with_empty_array,
     r#"
     indices([])


### PR DESCRIPTION
Better or worse, jq evaluates `null | indices(whatever)` to `null`. About test renaming, I didn't aware of the difference between `from_manual` and `hand_written`. Fixed the tests for `indices/1` to appropriate position (related to #36).