### PR TITLE
Fix split/1 with empty string, just as string division

### DIFF
--- a/prelude.jq
+++ b/prelude.jq
@@ -84,7 +84,6 @@ def combinations($n): [limit($n; repeat(.))] | combinations;
 def ltrimstr($s): if startswith($s) then .[($s | length):] else . end;
 def rtrimstr($s): if endswith($s) then .[:-($s | length)] else . end;
 
-def split($sep): index($sep) as $i | if $i == null then [.] else [.[0:$i]] + (.[($i + ($sep | length)):] | split($sep)) end;
 def join($sep): def stringify: label $out | ((nulls | ("", break $out)), ((booleans, numbers, strings) | (tostring, break $out)), error("Unsupported element \(.) on join")); if length == 0 then "" else reduce (.[1:][] | stringify) as $e (.[0] | stringify; . + $sep + $e) end;
 def ascii_downcase: explode | map(if . >= 65 and . <= 90 then .+32 end) | implode;
 def ascii_upcase: explode | map(if . >= 97 and . <= 122 then .-32 end) | implode;

--- a/src/intrinsic/binary.rs
+++ b/src/intrinsic/binary.rs
@@ -1,4 +1,5 @@
 use crate::{
+    intrinsic::string,
     lang::ast::BinaryArithmeticOp,
     vm::{bytecode::NamedFn1, QueryExecutionError},
     Number, Value,
@@ -126,17 +127,7 @@ fn divide(lhs: Value, rhs: Value) -> Result<Value, QueryExecutionError> {
             }
             Value::number(lhs / rhs)
         }
-        (String(lhs), String(rhs)) if rhs.is_empty() => lhs
-            .chars()
-            .map(|c| c.to_string().into())
-            .collect::<crate::Array>()
-            .into(),
-        (String(lhs), String(rhs)) => lhs
-            .split(&*rhs)
-            .into_iter()
-            .map(|s| s.to_string().into())
-            .collect::<crate::Array>()
-            .into(),
+        (String(lhs), String(rhs)) => string::split(lhs.as_ref(), rhs.as_ref()),
         (lhs @ (Null | Boolean(_) | Number(_) | String(_) | Array(_) | Object(_)), rhs) => {
             return Err(QueryExecutionError::IncompatibleBinaryOperator(
                 "divide", lhs, rhs,

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -80,6 +80,7 @@ static INTRINSICS1: phf::Map<&'static str, NamedFn1> = phf_map! {
     "indices" => NamedFn1 { name: "indices", func: indices },
     "startswith" => NamedFn1 { name: "startswith", func: starts_with },
     "endswith" => NamedFn1 { name: "endswith", func: ends_with },
+    "split" => NamedFn1 { name: "split", func: split1 },
     "delpaths" => NamedFn1 { name: "delpaths", func: path::del_paths },
     "bsearch" => NamedFn1 { name: "bsearch", func: binary_search },
 
@@ -302,10 +303,18 @@ fn starts_with(context: Value, s: Value) -> Result<Value> {
         (context, _) => Err(QueryExecutionError::InvalidArgType("startswith", context)),
     }
 }
+
 fn ends_with(context: Value, s: Value) -> Result<Value> {
     match (context, s) {
         (Value::String(lhs), Value::String(rhs)) => Ok(lhs.ends_with(rhs.as_ref()).into()),
         (context, _) => Err(QueryExecutionError::InvalidArgType("endswith", context)),
+    }
+}
+
+fn split1(context: Value, s: Value) -> Result<Value> {
+    match (context, s) {
+        (Value::String(lhs), Value::String(rhs)) => Ok(string::split(lhs.as_ref(), rhs.as_ref())),
+        (context, _) => Err(QueryExecutionError::InvalidArgType("split", context)),
     }
 }
 

--- a/src/intrinsic/string.rs
+++ b/src/intrinsic/string.rs
@@ -75,6 +75,21 @@ pub(crate) fn explode(value: Value) -> Result<Value> {
     }
 }
 
+pub(crate) fn split(lhs: &String, rhs: &String) -> Value {
+    if rhs.is_empty() {
+        lhs.chars()
+            .map(|c| c.to_string().into())
+            .collect::<Array>()
+            .into()
+    } else {
+        lhs.split(&*rhs)
+            .into_iter()
+            .map(|s| s.to_string().into())
+            .collect::<Array>()
+            .into()
+    }
+}
+
 pub(crate) fn implode(value: Value) -> Result<Value> {
     match value {
         Value::Array(s) => {


### PR DESCRIPTION
This PR fixes `split/1` to work with empty string. This filter is semantically same as string division so I refactored not to duplicate code.
```sh
❯ jq -nc '"abc" | split("b", "")'
["a","c"]
["a","b","c"]

❯ jq -nc '"abc" / ("b", "")'
["a","c"]
["a","b","c"]

❯ xq -nc '"abc" | split("b", "")'
["a","c"]
["abc"]  # oops!

❯ xq -nc '"abc" / ("b", "")'
["a","c"]
["a","b","c"]  # ok!

❯ xq --version
xq 0.2.9-f33b40cf049d2ef44a4fa0f75f92efc9255fda62
```