### PR TITLE
Move definition of split down a bit

### DIFF
--- a/src/intrinsic/string.rs
+++ b/src/intrinsic/string.rs
@@ -75,21 +75,6 @@ pub(crate) fn explode(value: Value) -> Result<Value> {
     }
 }
 
-pub(crate) fn split(lhs: &String, rhs: &String) -> Value {
-    if rhs.is_empty() {
-        lhs.chars()
-            .map(|c| c.to_string().into())
-            .collect::<Array>()
-            .into()
-    } else {
-        lhs.split(&*rhs)
-            .into_iter()
-            .map(|s| s.to_string().into())
-            .collect::<Array>()
-            .into()
-    }
-}
-
 pub(crate) fn implode(value: Value) -> Result<Value> {
     match value {
         Value::Array(s) => {
@@ -110,6 +95,21 @@ pub(crate) fn implode(value: Value) -> Result<Value> {
             Ok(Value::String(Rc::new(s)))
         }
         _ => Err(QueryExecutionError::InvalidArgType("implode", value)),
+    }
+}
+
+pub(crate) fn split(lhs: &String, rhs: &String) -> Value {
+    if rhs.is_empty() {
+        lhs.chars()
+            .map(|c| c.to_string().into())
+            .collect::<Array>()
+            .into()
+    } else {
+        lhs.split(rhs)
+            .into_iter()
+            .map(|s| s.to_string().into())
+            .collect::<Array>()
+            .into()
     }
 }
 


### PR DESCRIPTION
I noticed that I placed between explode and implode, but I was to place down after implode (ref: #90). Also I think `&*rhs` is ok to be replaced by `rhs` but is that right?