### PR TITLE
Fix sh format on array

### DIFF
--- a/src/intrinsic/string.rs
+++ b/src/intrinsic/string.rs
@@ -218,8 +218,13 @@ fn tsv(value: Value) -> Result<Value> {
 }
 
 fn sh(value: Value) -> Result<Value> {
-    let s = stringify_inner(value);
-    let ret = shell_escape::escape(Cow::from(make_owned(s))).to_string();
+    let escape = |value: Value| {
+        shell_escape::escape(Cow::from(make_owned(stringify_inner(value)))).to_string()
+    };
+    let ret = match value {
+        Value::Array(arr) => arr.iter().map(|value| escape(value.clone())).join(" "),
+        _ => escape(value),
+    };
     Ok(ret.into())
 }
 

--- a/tests/hand_written/mod.rs
+++ b/tests/hand_written/mod.rs
@@ -586,3 +586,18 @@ test!(
     "err"
     "#
 );
+
+test!(
+    string_format_sh,
+    r#"
+    @sh "\(0, "a b c", [0,null,true,"a b c"])"
+    "#,
+    r#"
+    null
+    "#,
+    r#"
+    "0"
+    "'a b c'"
+    "0 null true 'a b c'"
+    "#
+);


### PR DESCRIPTION
This PR fixes the sh format on array.
```sh
❯ jq -nr '@sh "\(0, "a b c", [0,null,true,"a b c"])"'
0
'a b c'
0 null true 'a b c'

❯ xq -nr '@sh "\(0, "a b c", [0,null,true,"a b c"])"'
0
'a b c'
'[0,null,true,"a b c"]'

❯ xq --version
xq 0.2.10-7adfc7251091a68a8d0a28360a7ba4a54ef8588e
```
This is documented in the [jq Manual](https://stedolan.github.io/jq/manual/) as `If the input is an array, the output will be a series of space-separated strings.`.