### PR TITLE
Improve keys, keys_unsorted performance

### DIFF
--- a/prelude.jq
+++ b/prelude.jq
@@ -41,9 +41,6 @@ def first: .[0];
 def last: .[-1];
 def nth($n): .[$n];
 
-def keys_unsorted: [path(.[])[]];
-def keys: keys_unsorted | sort;
-
 def del(f): delpaths([path(f)]);
 def setpath($paths; $v): getpath($paths) |= $v;
 

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -37,6 +37,8 @@ static INTRINSICS0: phf::Map<&'static str, NamedFn0> = phf_map! {
     "type" => NamedFn0 { name: "type", func: get_type },
     "length" => NamedFn0 { name: "length", func: length },
     "utf8bytelength" => NamedFn0 { name: "utf8bytelength", func: utf8_byte_length },
+    "keys_unsorted" =>  NamedFn0 { name: "keys_unsorted", func: keys_unsorted },
+    "keys" =>  NamedFn0 { name: "keys", func: keys },
     "sort" => NamedFn0 { name: "sort", func: sort },
     "reverse" => NamedFn0 { name: "reverse", func: reverse },
     "tostring" => NamedFn0 { name: "tostring", func: text },
@@ -157,6 +159,40 @@ fn utf8_byte_length(context: Value) -> Result<Value> {
     match context {
         Value::String(s) => Ok(Value::number(s.len())),
         _ => Err(QueryExecutionError::InvalidUTF8ByteLength(context)),
+    }
+}
+
+fn keys_unsorted(context: Value) -> Result<Value> {
+    match context {
+        Value::Array(arr) => Ok((0..arr.len())
+            .map(|i| Value::number(i))
+            .collect::<Array>()
+            .into()),
+        Value::Object(obj) => Ok(obj
+            .keys()
+            .map(|k| k.to_string().into())
+            .collect::<Array>()
+            .into()),
+        _ => Err(QueryExecutionError::InvalidArgType(
+            "keys_unsorted",
+            context,
+        )),
+    }
+}
+
+fn keys(context: Value) -> Result<Value> {
+    match context {
+        Value::Array(arr) => Ok((0..arr.len())
+            .map(|i| Value::number(i))
+            .collect::<Array>()
+            .into()),
+        Value::Object(obj) => Ok(obj
+            .keys()
+            .sorted()
+            .map(|k| k.to_string().into())
+            .collect::<Array>()
+            .into()),
+        _ => Err(QueryExecutionError::InvalidArgType("keys", context)),
     }
 }
 

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -164,10 +164,7 @@ fn utf8_byte_length(context: Value) -> Result<Value> {
 
 fn keys_unsorted(context: Value) -> Result<Value> {
     match context {
-        Value::Array(arr) => Ok((0..arr.len())
-            .map(|i| Value::number(i))
-            .collect::<Array>()
-            .into()),
+        Value::Array(arr) => Ok((0..arr.len()).map(Value::number).collect::<Array>().into()),
         Value::Object(obj) => Ok(obj
             .keys()
             .map(|k| k.to_string().into())
@@ -182,10 +179,7 @@ fn keys_unsorted(context: Value) -> Result<Value> {
 
 fn keys(context: Value) -> Result<Value> {
     match context {
-        Value::Array(arr) => Ok((0..arr.len())
-            .map(|i| Value::number(i))
-            .collect::<Array>()
-            .into()),
+        Value::Array(arr) => Ok((0..arr.len()).map(Value::number).collect::<Array>().into()),
         Value::Object(obj) => Ok(obj
             .keys()
             .sorted()


### PR DESCRIPTION
The definition of `keys_unsorted` using `path/1` is very interesting (honestly I didn't come up with this definition), but should have some overhead. Since `keys` is used widely, improving its performance by internal implementation is worth considering. What do you think?
```sh
❯ env q='[range(10000)] | keys' hyperfine --warmup 10 'xq-new -n "$q"' 'xq-old -n "$q"'
Benchmark 1: xq-new -n "$q"
  Time (mean ± σ):      17.2 ms ±   0.8 ms    [User: 14.5 ms, System: 2.2 ms]
  Range (min … max):    15.9 ms …  21.9 ms    153 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: xq-old -n "$q"
  Time (mean ± σ):      37.6 ms ±   1.2 ms    [User: 34.8 ms, System: 2.2 ms]
  Range (min … max):    36.3 ms …  45.0 ms    75 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  'xq-new -n "$q"' ran
    2.18 ± 0.12 times faster than 'xq-old -n "$q"'
```

By the way, note that `keys_unsorted` is not the insertion order.
```sh
❯ xq -nc '{c:1,a:2,b:3} | keys_unsorted'
["c","a","b"]

❯ xq -nc '{c:1,a:2,b:3} | keys_unsorted' # oops, changes each execution
["a","c","b"]
```