### PR TITLE
Change indexing string by out of range to emit null

### DIFF
--- a/src/intrinsic/index.rs
+++ b/src/intrinsic/index.rs
@@ -64,7 +64,7 @@ pub(crate) fn index(value: Value, index: Value) -> Result<(Value, PathElement)> 
                 Ok((
                     idx.and_then(|i| s.chars().nth(i))
                         .map(|c| Value::string(String::from(c)))
-                        .unwrap_or_else(|| Value::string("".to_string())),
+                        .unwrap_or_else(|| Value::Null),
                     PathElement::Any(index),
                 ))
             }

--- a/tests/hand_written/mod.rs
+++ b/tests/hand_written/mod.rs
@@ -320,6 +320,22 @@ test!(
 );
 
 test!(
+    index_string,
+    r#"
+    .[0, 3, 5, -3]
+    "#,
+    r#"
+    "０１２３４"
+    "#,
+    r#"
+    "０"
+    "３"
+    null
+    "２"
+    "#
+);
+
+test!(
     index_array_by_object,
     r#"
     .[{start:(null,range(3)), end:(null,range(3))}]


### PR DESCRIPTION
While the current implementation is same as gojq v0.12.7, I changed in the HEAD version to emit `null` for indexing string by out of range. This is more consistent with array indexing and behaviors of other languages; in JavaScript `"abcde"[10]` results in `undefined`, not `""`. What do you think?
