### PR TITLE
Fix deletion of negative index of array out of range

### DIFF
--- a/src/intrinsic/path.rs
+++ b/src/intrinsic/path.rs
@@ -224,7 +224,7 @@ fn replace_tombstone_rec(context: Value, path: &[Value], placeholder: Value) -> 
                     .to_isize()
                     .ok_or_else(|| QueryExecutionError::InvalidIndex(index.clone()))?;
                 if i + (arr.len() as isize) < 0 {
-                    return Err(QueryExecutionError::InvalidIndex(index.clone()));
+                    return Ok(arr.into());
                 }
                 let i = if i < 0 {
                     (i + arr.len() as isize) as usize

--- a/tests/hand_written/mod.rs
+++ b/tests/hand_written/mod.rs
@@ -669,6 +669,19 @@ test!(
 test!(
     delete3,
     r#"
+    {x:[1]} | del(.x[-2,-1,2])
+    "#,
+    r#"
+    null
+    "#,
+    r#"
+    {"x":[]}
+    "#
+);
+
+test!(
+    delete4,
+    r#"
     try ({x:[1]} | del(.x.y, .x[0], .x)) catch "err"
     "#,
     r#"
@@ -680,7 +693,7 @@ test!(
 );
 
 test!(
-    delete4,
+    delete5,
     r#"
     try ({x:[1]} | del(.x[0], .x.y, .x)) catch "err"
     "#,


### PR DESCRIPTION
Deletion of paths with negative index out of range should not raise error.
```sh
❯ jq -n '[1,2,3] | del(.[-10])'
[
  1,
  2,
  3
]

❯ xq -n '[1,2,3] | del(.[-10])'
Error: InvalidIndex(-10)
```