### PR TITLE
Refactor implementation of group_by filter

### DIFF
--- a/prelude.jq
+++ b/prelude.jq
@@ -64,6 +64,7 @@ def min_by(f): reduce (.[] | [[f], .]) as [$cmp, $val] (null; if . == null or .[
 def max_by(f): reduce (.[] | [[f], .]) as [$cmp, $val] (null; if . == null or .[0] <= $cmp then [$cmp, $val] end) | .[1];
 def min: min_by(.);
 def max: max_by(.);
+def group_by(f): _group_by(map([f]));
 def unique_by(f): def __yes_i_know_this_is_bad:.; [group_by(f)[] | .[0]];
 def unique: unique_by(.);
 

--- a/src/compile/compiler.rs
+++ b/src/compile/compiler.rs
@@ -524,36 +524,6 @@ impl Compiler {
                         Ok(next)
                     })
                 }
-                "group_by" => {
-                    FunctionLike::ManuallyImplemented("group_by", |compiler, args, next| {
-                        assert_eq!(1, args.len());
-                        let grouping = &args[0];
-                        // [.[] | [ [grouping], . ]] | group_by_impl
-                        let arg = Term::Array(Some(Box::new(Query::Pipe {
-                            lhs: Box::new(
-                                Term::Suffix(Term::Identity.into(), Suffix::Iterate).into(),
-                            ),
-                            rhs: Box::new(
-                                Term::Array(Some(Box::new(Query::Concat {
-                                    lhs: Box::new(
-                                        Term::Array(Some(Box::new(grouping.clone()))).into(),
-                                    ),
-                                    rhs: Box::new(Term::Identity.into()),
-                                })))
-                                .into(),
-                            ),
-                        })));
-                        let next = compiler.emitter.emit_normal_op(
-                            ByteCode::Intrinsic0(NamedFn0 {
-                                name: "group_by",
-                                func: intrinsic::group_by,
-                            }),
-                            next,
-                        );
-                        let next = compiler.compile_term(&arg, next)?;
-                        Ok(next)
-                    })
-                }
                 _ => return None,
             },
             _ => return None,

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -72,6 +72,8 @@ pub enum QueryExecutionError {
     InvalidStringToNumber(RcString),
     #[error("Given string was invalid as a json `{0:}`")]
     InvalidJson(RcString),
+    #[error("Length mismatch for `{0:?}`")]
+    LengthMismatch(&'static str),
     #[error("Unknown string formatter `{0:?}`")]
     UnknownStringFormatter(RcString),
     #[error("Unable to parse date time")]


### PR DESCRIPTION
I refactored the implementation of `group_by` to make the compiler implementation simpler.