### PR TITLE
Fix path tracking on value arguments

### DIFF
--- a/src/compile/compiler.rs
+++ b/src/compile/compiler.rs
@@ -663,6 +663,9 @@ impl Compiler {
                         .emit_normal_op(ByteCode::PushClosure(closure), next);
                 }
                 ArgType::Value => {
+                    next = self
+                        .emitter
+                        .emit_normal_op(ByteCode::ExitNonPathTracking, next);
                     if require_context {
                         next = self.emitter.emit_normal_op(ByteCode::Swap, next);
                     }
@@ -672,6 +675,9 @@ impl Compiler {
                     } else {
                         require_context = true;
                     }
+                    next = self
+                        .emitter
+                        .emit_normal_op(ByteCode::EnterNonPathTracking, next);
                 }
             }
         }

--- a/tests/hand_written/mod.rs
+++ b/tests/hand_written/mod.rs
@@ -877,3 +877,16 @@ test!(
     "🤔"
     "#
 );
+
+test!(
+    path_value_argument,
+    r#"
+    def f($x): .y; path(f(.x))
+    "#,
+    r#"
+    null
+    "#,
+    r#"
+    ["y"]
+    "#
+);


### PR DESCRIPTION
I received a bug report to gojq (https://github.com/itchyny/gojq/issues/186). This bug is reproducible in xq as well. I fixed the bug.
```
 $ xq -n 'def f($x): .y; path(f(.x))'
[
  "x",
  "y"
]
 $ jq -n 'def f($x): .y; path(f(.x))'
[
  "y"
]
```