### PR TITLE
Fix update-assignment operator on overlapping paths (fix #156)

### DIFF
--- a/tests/hand_written/assignments.rs
+++ b/tests/hand_written/assignments.rs
@@ -120,3 +120,16 @@ test!(
     [1,2,null,null,5,3]
     "#
 );
+
+test!(
+    overlapping_update,
+    r#"
+    (.foo,.foo,.foo) |= . + 1
+    "#,
+    r#"
+    null
+    "#,
+    r#"
+    {"foo":3}
+    "#
+);


### PR DESCRIPTION
This PR fixes the update-assignment operator `|=` to be more compatible with jq, fixing #156.