### PR TITLE
feat(tracing): move to tracing library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -143,32 +143,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -179,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -399,6 +397,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +498,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +562,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -645,6 +695,12 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -811,7 +867,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1218,6 +1274,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,12 +1534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,7 +1605,7 @@ dependencies = [
  "serde-xml-rs",
  "thiserror",
  "time",
- "windows-sys",
+ "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -1825,12 +1889,33 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1839,10 +1924,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1851,16 +1948,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "xml-rs"
@@ -1875,7 +1996,7 @@ dependencies = [
  "anyhow",
  "base64",
  "cast 0.3.0",
- "clap 3.2.23",
+ "clap 4.0.32",
  "criterion",
  "derive_more",
  "html-escape",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,19 +137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time 0.1.43",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,42 +149,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.15.0",
-]
-
-[[package]]
-name = "clap-verbosity-flag"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e437250f23cdd03daf3de763093aa27873a026ef9a156800da9ddd617c51d4"
-dependencies = [
- "clap 3.1.6",
- "log",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -650,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "linked-hash-map"
@@ -721,6 +707,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num"
@@ -829,6 +825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
 name = "onig"
 version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,9 +882,12 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -989,6 +994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,11 +1077,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1305,6 +1316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,17 +1341,6 @@ name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
-
-[[package]]
-name = "simplelog"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1348164456f72ca0116e4538bdaabb0ddb622c7d9f16387c725af3e96d6001c"
-dependencies = [
- "chrono",
- "log",
- "termcolor",
-]
 
 [[package]]
 name = "siphasher"
@@ -1351,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "snapbox"
@@ -1402,13 +1411,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1456,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -1481,13 +1490,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
+name = "thread_local"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
- "libc",
- "winapi",
+ "once_cell",
 ]
 
 [[package]]
@@ -1509,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ecd582b4dcb8b5dc526c7664d82ea19d0c11cb0d14fd0ba04c968f38c5b0c0"
 dependencies = [
  "thiserror",
- "time 0.3.7",
+ "time",
 ]
 
 [[package]]
@@ -1532,7 +1540,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "thiserror",
- "time 0.3.7",
+ "time",
  "windows-sys",
 ]
 
@@ -1569,6 +1577,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "trycmd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1655,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"
@@ -1613,6 +1685,12 @@ name = "utf8-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1797,14 +1875,12 @@ dependencies = [
  "anyhow",
  "base64",
  "cast 0.3.0",
- "clap 3.1.6",
- "clap-verbosity-flag",
+ "clap 3.2.23",
  "criterion",
  "derive_more",
  "html-escape",
  "imbl",
  "itertools",
- "log",
  "num",
  "num-derive",
  "num-traits",
@@ -1815,12 +1891,13 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shell-escape",
- "simplelog",
  "sized-chunks",
  "thiserror",
- "time 0.3.7",
+ "time",
  "time-fmt",
  "time-tz",
+ "tracing",
+ "tracing-subscriber",
  "trycmd",
  "urlencoding",
  "xq-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,17 @@ pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ targe
 pkg-fmt = "zip"
 
 [package.metadata.release]
-pre-release-hook = ["cargo", "update", "--manifest-path", "./fuzz/Cargo.toml", "-p", "xq"]
+pre-release-hook = [
+    "cargo",
+    "update",
+    "--manifest-path",
+    "./fuzz/Cargo.toml",
+    "-p",
+    "xq",
+]
 
 [workspace]
-members = [ "crates/*" ]
+members = ["crates/*"]
 
 [[bin]]
 name = "xq"
@@ -34,7 +41,7 @@ harness = false
 
 [features]
 default = ["build-binary"]
-build-binary = ["anyhow", "clap", "clap-verbosity-flag", "simplelog", "serde_yaml"]
+build-binary = ["anyhow", "clap", "tracing-subscriber", "serde_yaml"]
 
 [profile.release]
 strip = "symbols"
@@ -47,7 +54,7 @@ opt-level = 3
 [dependencies]
 xq-lang = { path = "./crates/lang", version = "0.0.1" }
 thiserror = "1.0.30"
-log = "0.4.14"
+tracing = "0, >= 0.1"
 imbl = "1.0.1"
 sized-chunks = "0.6.5"
 num = "0.4.0"
@@ -70,12 +77,12 @@ time-tz = { version = "0.5.2", features = ["system", "posix-tz"] }
 onig = { version = "6.3.1", default-features = false }
 
 clap = { version = "3.1.6", features = ["derive"], optional = true }
-clap-verbosity-flag = { version = "1.0.0", optional = true }
-anyhow = { version = "1.0.56", optional = true }
-simplelog = { version = "0.11.2", optional = true }
+anyhow = { version = "1", optional = true }
+tracing-subscriber = { version = "0, >= 0.3", optional = true, features = [
+    "registry",
+] }
 serde_yaml = { version = "0.8.23", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.5"
 trycmd = "0.13.3"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ time-fmt = "0.3.4"
 time-tz = { version = "0.5.2", features = ["system", "posix-tz"] }
 onig = { version = "6.3.1", default-features = false }
 
-clap = { version = "3.1.6", features = ["derive"], optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
 anyhow = { version = "1", optional = true }
 tracing-subscriber = { version = "0, >= 0.3", optional = true, features = [
     "registry",

--- a/benches/prelude.rs
+++ b/benches/prelude.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
-const PRELUDE: &'static str = include_str!("../prelude.jq");
+const PRELUDE: &str = include_str!("../prelude.jq");
 
 struct NullModuleLoader;
 impl xq::module_loader::ModuleLoader for NullModuleLoader {

--- a/src/bin/cli/formats.rs
+++ b/src/bin/cli/formats.rs
@@ -1,0 +1,20 @@
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum SerializationFormat {
+    Json,
+    Raw,
+    Yaml,
+}
+
+#[derive(Clone, Debug)]
+pub enum InputFormat {
+    Simple(SerializationFormat),
+    Slurp(SerializationFormat),
+}
+
+#[derive(Clone, Debug)]
+pub enum OutputFormat {
+    Simple(SerializationFormat),
+    Compact(SerializationFormat),
+    Pretty(SerializationFormat),
+    Slurp(SerializationFormat),
+}

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -1,1 +1,4 @@
 pub(crate) mod input;
+
+mod verbosity;
+pub(crate) use verbosity::Verbosity;

--- a/src/bin/cli/verbosity.rs
+++ b/src/bin/cli/verbosity.rs
@@ -1,0 +1,54 @@
+use tracing::Level;
+use tracing_subscriber::{filter::Targets, prelude::*};
+
+#[derive(clap::Args, Debug)]
+pub struct Verbosity {
+    /// Increase verbosity or the output
+    ///
+    /// The verbosity only apply to the logging of the crate,
+    /// logging from other crates are filtered to INFO.
+    #[clap(short, long, help_heading = "Verbosity", action = clap::ArgAction::Count)]
+    verbose: u8,
+
+    /// Reduce verbosity of the output
+    #[clap(short, long, help_heading = "Verbosity", action = clap::ArgAction::Count, conflicts_with = "verbose")]
+    quiet: u8,
+}
+
+impl Verbosity {
+    pub(crate) fn configure(&self) {
+        #[cfg(debug_assertions)]
+        let show_details = true;
+        #[cfg(not(debug_assertions))]
+        let show_details = false;
+
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .pretty()
+                    .with_file(show_details)
+                    .with_target(show_details),
+            )
+            .with::<Targets>(self.into())
+            .init();
+    }
+}
+
+impl From<&Verbosity> for tracing_subscriber::filter::Targets {
+    fn from(val: &Verbosity) -> Self {
+        tracing_subscriber::filter::Targets::new()
+            // Enable the `WARN` level for anything not `xq`
+            .with_default(Level::WARN)
+            // Use CLI verbosity to determine the level of logging asked
+            .with_target(
+                "xq",
+                match val.verbose as i16 - val.quiet as i16 {
+                    ..=-1 => Level::ERROR,
+                    0 => Level::WARN,
+                    1 => Level::INFO,
+                    2 => Level::DEBUG,
+                    3.. => Level::TRACE,
+                },
+            )
+    }
+}

--- a/src/compile/compiler.rs
+++ b/src/compile/compiler.rs
@@ -731,7 +731,6 @@ impl Compiler {
                 if matches!(self.emitter.get_next_op(next), ByteCode::Ret)
                     && !self.current_scope().has_slot_leaked_scope()
                 {
-                    // log::info!("Tail call closure for slot {:?}", slot);
                     self.emitter
                         .emit_terminal_op(ByteCode::TailCallClosure(slot))
                 } else {

--- a/src/data_structure/undo/stack.rs
+++ b/src/data_structure/undo/stack.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 use derive_more::Display;
 use itertools::Itertools;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod data_structure;
 mod intrinsic;
 pub mod module_loader;
 mod number;
+mod prelude;
 pub mod util;
 mod value;
 pub mod vm;
@@ -14,6 +15,7 @@ use xq_lang::ParseError;
 use crate::{
     compile::compiler::{CompileError, Compiler},
     module_loader::ModuleLoader,
+    prelude::*,
     vm::{machine::Machine, QueryExecutionError},
 };
 pub use crate::{
@@ -44,16 +46,12 @@ where
     I: Iterator<Item = Result<Value, InputError>>,
     M: ModuleLoader,
 {
-    // let now = std::time::Instant::now();
     let parsed = xq_lang::parse_program(query)?;
-    log::info!("Parsed query = {:?}", parsed);
-    // eprintln!("Parse: {:?}", now.elapsed());
-    // let now = std::time::Instant::now();
+    trace!("Parsed query = {:?}", parsed);
 
     let mut compiler = Compiler::new();
     let program = compiler.compile(&parsed, module_loader)?;
-    log::info!("Compiled program = {:?}", program);
-    // eprintln!("Compile: {:?}", now.elapsed());
+    trace!("Compiled program = {:?}", program);
 
     let mut vm = Machine::new(program);
     Ok(vm.start(context, input))

--- a/src/number.rs
+++ b/src/number.rs
@@ -26,8 +26,8 @@ pub(crate) type PrimitiveReal = f64;
     num_derive::Num,
     num_derive::Float,
 )]
-#[debug(fmt = "{}", _0)]
-#[display(fmt = "{}", _0)]
+#[debug(fmt = "{_0}")]
+#[display(fmt = "{_0}")]
 pub struct Number(OrderedFloat<PrimitiveReal>);
 
 impl Number {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,1 @@
+pub use tracing::*;

--- a/src/value.rs
+++ b/src/value.rs
@@ -28,13 +28,13 @@ pub type RcString = Rc<String>;
 #[derive(
     Clone, Eq, PartialEq, Hash, Default, DebugCustom, Display, IntoIterator, Index, IndexMut,
 )]
-#[debug(fmt = "{:?}", _0)]
-#[display(fmt = "{:?}", _0)]
+#[debug(fmt = "{_0:?}")]
+#[display(fmt = "{_0:?}")]
 pub struct Array(#[into_iterator(owned, ref, ref_mut)] Vector);
 
 #[derive(Clone, Eq, PartialEq, Default, DebugCustom, Display, IntoIterator, Index, IndexMut)]
-#[debug(fmt = "{:?}", _0)]
-#[display(fmt = "{:?}", _0)]
+#[debug(fmt = "{_0:?}")]
+#[display(fmt = "{_0:?}")]
 pub struct Object(#[into_iterator(owned, ref, ref_mut)] Map);
 
 #[allow(clippy::derive_hash_xor_eq)] // HashMap::eq is implemented properly.
@@ -212,9 +212,9 @@ impl Debug for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Value::Null => f.write_str("null"),
-            Value::Boolean(v) => f.write_fmt(format_args!("{:?}", v)),
-            Value::Number(v) => f.write_fmt(format_args!("{:?}", v)),
-            Value::String(v) => f.write_fmt(format_args!("{:?}", v)),
+            Value::Boolean(v) => f.write_fmt(format_args!("{v:?}")),
+            Value::Number(v) => f.write_fmt(format_args!("{v:?}")),
+            Value::String(v) => f.write_fmt(format_args!("{v:?}")),
             Value::Array(v) => f.write_fmt(format_args!("{:?}", v.as_ref())),
             Value::Object(v) => f.write_fmt(format_args!("{:?}", v.as_ref())),
         }
@@ -224,9 +224,9 @@ impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Value::Null => f.write_str("null"),
-            Value::Boolean(v) => f.write_fmt(format_args!("{:?}", v)),
-            Value::Number(v) => f.write_fmt(format_args!("{:?}", v)),
-            Value::String(v) => f.write_fmt(format_args!("{:?}", v)),
+            Value::Boolean(v) => f.write_fmt(format_args!("{v:?}")),
+            Value::Number(v) => f.write_fmt(format_args!("{v:?}")),
+            Value::String(v) => f.write_fmt(format_args!("{v:?}")),
             Value::Array(arr) => {
                 f.write_str("[")?;
                 let mut first = true;
@@ -249,7 +249,7 @@ impl Display for Value {
                     } else {
                         f.write_str(", ")?;
                     }
-                    f.write_fmt(format_args!("{}: {}", k, v))?;
+                    f.write_fmt(format_args!("{k}: {v}"))?;
                 }
                 f.write_str("}")
             }

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -100,24 +100,24 @@ pub enum QueryExecutionError {
 
 impl From<time_fmt::parse::ParseError> for QueryExecutionError {
     fn from(e: time_fmt::parse::ParseError) -> Self {
-        Self::DateTimeParseError(Rc::new(format!("{}", e)))
+        Self::DateTimeParseError(Rc::new(format!("{e}")))
     }
 }
 
 impl From<time_fmt::format::FormatError> for QueryExecutionError {
     fn from(e: time_fmt::format::FormatError) -> Self {
-        Self::DateTimeParseError(Rc::new(format!("{}", e)))
+        Self::DateTimeParseError(Rc::new(format!("{e}")))
     }
 }
 
 impl From<time::error::Parse> for QueryExecutionError {
     fn from(e: time::error::Parse) -> Self {
-        Self::DateTimeParseError(Rc::new(format!("{}", e)))
+        Self::DateTimeParseError(Rc::new(format!("{e}")))
     }
 }
 
 impl From<time_tz::system::Error> for QueryExecutionError {
     fn from(e: time_tz::system::Error) -> Self {
-        Self::TimeZoneLookupFailure(Rc::new(format!("{}", e)))
+        Self::TimeZoneLookupFailure(Rc::new(format!("{e}")))
     }
 }

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -16,6 +16,7 @@ use crate::{
         PStack, PVector,
     },
     intrinsic,
+    prelude::*,
     util::make_owned,
     vm::{
         bytecode::{ClosureAddress, NamedFunction},
@@ -490,9 +491,9 @@ fn run_code(
     input: &mut impl Iterator<Item = Result<Value, InputError>>,
 ) -> Option<Result<Value>> {
     let mut err: Option<QueryExecutionError> = None;
-    log::trace!("Start from environment {:?}", env);
+    trace!("Start from environment {:?}", env);
     'backtrack: loop {
-        log::trace!(
+        trace!(
             "Fork stack: {:?}",
             env.forks.iter().map(|(_, f)| f).collect_vec()
         );
@@ -503,7 +504,7 @@ fn run_code(
             } else {
                 return err.map(Err);
             };
-            log::trace!(
+            trace!(
                 "On fork {:?} with err {:?} and token {:?}",
                 on_fork,
                 err,
@@ -601,13 +602,13 @@ fn run_code(
         let mut context_frame: Option<Frames> = None;
         let mut chain_ret = false;
 
-        log::trace!("Start fork with state {:?}", state);
+        trace!("Start fork with state {:?}", state);
         'cycle: loop {
             if err.is_some() {
                 continue 'backtrack;
             }
             let code = program.fetch_code(state.pc)?;
-            log::trace!(
+            trace!(
                 "Execute code {:?} on stack = {:?}, slots = {:?}",
                 code,
                 state.stack,
@@ -929,7 +930,7 @@ fn run_code(
                 },
                 Intrinsic0(NamedFunction { name, func }) => {
                     let context = state.pop();
-                    log::trace!("Calling function {} with context {:?}", name, context);
+                    trace!("Calling function {} with context {:?}", name, context);
                     match func(context) {
                         Ok(value) => state.push(value),
                         Err(QueryExecutionError::UserDefinedError(Value::Null)) => {
@@ -941,7 +942,7 @@ fn run_code(
                 Intrinsic1(NamedFunction { name, func }) => {
                     let arg1 = state.pop();
                     let context = state.pop();
-                    log::trace!(
+                    trace!(
                         "Calling function {} with context {:?} and arg {:?}",
                         name,
                         context,
@@ -959,7 +960,7 @@ fn run_code(
                     let arg2 = state.pop();
                     let arg1 = state.pop();
                     let context = state.pop();
-                    log::trace!(
+                    trace!(
                         "Calling function {} with context {:?} and arg1 {:?} and arg2 {:?}",
                         name,
                         context,

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -263,7 +263,7 @@ impl State {
         match self.paths.pop() {
             Some(Some((value, _, path))) => (value, path),
             x => {
-                panic!("Expected a path tracking thing but got {:?}", x);
+                panic!("Expected a path tracking thing but got {x:?}");
             }
         }
     }
@@ -544,7 +544,7 @@ fn run_code(
                             }
                             Some(e) => {
                                 state.undo(token);
-                                state.push(Value::string(format!("{:?}", e)));
+                                state.push(Value::string(format!("{e:?}")));
                                 break 'select_fork state.save();
                             }
                         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,7 +7,7 @@ macro_rules! test {
     ($name: ident, $query: expr, $input: expr, $output: expr) => {
         #[test]
         fn $name() -> Result<(), Box<dyn std::error::Error>> {
-            crate::common::run_test($query, $input, $output)
+            $crate::common::run_test($query, $input, $output)
         }
     };
 }
@@ -24,7 +24,7 @@ pub(crate) fn run_test(query: &str, input: &str, output: &str) -> Result<(), Box
     let output = run_query(query, input.clone(), input, &PreludeLoader())?
         .collect::<Result<Vec<Value>, _>>()?;
     if expected != output {
-        eprintln!("{:?} {:?}", expected, output);
+        eprintln!("{expected:?} {output:?}");
     }
     assert_eq!(expected, output);
     Ok(())
@@ -35,7 +35,7 @@ macro_rules! test_no_panic {
     ($name: ident, $query: expr, $input: expr) => {
         #[test]
         fn $name() {
-            crate::common::test_no_panic($query, $input).ok();
+            $crate::common::test_no_panic($query, $input).ok();
         }
     };
 }


### PR DESCRIPTION
This is IMO the first step toward #119; the ability to have structured logs will for sure be useful for it.
As a bonus, I updated `clap` to 4.0 and fixed `clippy` pestering about variables in `format!` directly.

- feat(tracing): move to tracing library
- chore(deps): update clap to 4.0
- chore(clippy): fix clippy warnings
