### PR TITLE
Use only XQ_COLORS for colors and drop fallback to JQ_COLORS

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -151,7 +151,7 @@ fn init_log(verbosity: &Verbosity) -> Result<()> {
 
 fn get_json_style() -> colored_json::Styler {
     fn set_env_colors(styler: &mut colored_json::Styler) -> Result<()> {
-        if let Ok(env_colors) = std::env::var("XQ_COLORS").or_else(|_| std::env::var("JQ_COLORS")) {
+        if let Ok(env_colors) = std::env::var("XQ_COLORS") {
             let env_colors = env_colors.split(':');
             for (i, env_color) in env_colors.enumerate().take(7) {
                 let styles = match i {
@@ -204,7 +204,8 @@ fn get_json_style() -> colored_json::Styler {
         nil_value: colored_json::Style::new(colored_json::Color::Default).dimmed(),
         ..Default::default()
     };
-    set_env_colors(&mut styler).unwrap_or_else(|_| eprintln!("Failed to set $JQ_COLORS"));
+    set_env_colors(&mut styler)
+        .unwrap_or_else(|_| eprintln!("Failed to set colors from $XQ_COLORS"));
     styler
 }
 


### PR DESCRIPTION
I'm bothered by `Failed to set $JQ_COLORS` error message on invoking xq. I configure `JQ_COLORS="38;5;248:38;5;214:38;5;224:38;5;45:38;5;82:::38;5;123"` and that looks unacceptable by xq. Although jq manual doesn't mention entirely about how it is handled, it accepts any semicolon-separated numbers for CSI. For example, `JQ_COLORS="48;5;91" jq -n .` can change the background color. Also the JQ_COLORS fallback disables to use the default colors of xq while configuring colors for jq. If we want to use the same colors, we simply can `export XQ_COLORS=$JQ_COLORS`.