### PR TITLE
Fix modulo operator on NaN to emit NaN

### DIFF
--- a/src/intrinsic/binary.rs
+++ b/src/intrinsic/binary.rs
@@ -142,6 +142,9 @@ fn modulo(lhs: Value, rhs: Value) -> Result<Value, QueryExecutionError> {
     use Value::*;
     Ok(match (lhs, rhs) {
         (Number(lhs), Number(rhs)) => {
+            if lhs.is_nan() || rhs.is_nan() {
+                return Ok(Value::number(f64::NAN));
+            }
             let rhs = number_to_i64(rhs);
             if rhs == 0 {
                 return Err(QueryExecutionError::DivModByZero);

--- a/tests/hand_written/mod.rs
+++ b/tests/hand_written/mod.rs
@@ -640,6 +640,22 @@ test!(
 );
 
 test!(
+    modulo_nan,
+    r#"
+    (1, nan) % (1, nan) | isnan
+    "#,
+    r#"
+    null
+    "#,
+    r#"
+    false
+    true
+    true
+    true
+    "#
+);
+
+test!(
     delete1,
     r#"
     [1,2,3] | (del(.[1:2][0]), del(.[1:2][1], .[1]))


### PR DESCRIPTION
The modulo operator in jq and gojq emits NaN when either side is NaN, just like other binary operators.