### PR TITLE
Implement pick/1 filter

### DIFF
--- a/prelude.jq
+++ b/prelude.jq
@@ -41,6 +41,7 @@ def nth($n): .[$n];
 
 def del(f): delpaths([path(f)]);
 def setpath($paths; $v): getpath($paths) |= $v;
+def pick(f): . as $v | reduce path(f) as $p (null; setpath($p; $v | getpath($p)));
 
 def to_entries: [keys[] as $key | {$key, value: .[$key]}];
 def from_entries: reduce .[] as $entry ({}; .[$entry.key]=$entry.value);

--- a/tests/from_manual/functions.rs
+++ b/tests/from_manual/functions.rs
@@ -265,6 +265,19 @@ test!(
 );
 
 test!(
+    pick1,
+    r#"
+    pick(.x, .y[2], .y[0], .z)
+    "#,
+    r#"
+    {"x":1,"y":[1,2,3]}
+    "#,
+    r#"
+    {"x":1,"y":[1,null,3],"z":null}
+    "#
+);
+
+test!(
     entries1,
     r#"
     to_entries


### PR DESCRIPTION
This PR implements `pick/1` filter, added in [jq 1.7](https://github.com/jqlang/jq/releases/tag/jq-1.7).