### PR TITLE
Implement abs/0 filter

### DIFF
--- a/prelude.jq
+++ b/prelude.jq
@@ -2,6 +2,7 @@ def not: if . then false else true end;
 def select(f): if f then . else empty end;
 def map(f): [.[] | f];
 def map_values(f): .[] |= f;
+def abs: if . < 0 then - . else . end;
 
 def isfinite: isinfinite | not;
 def nulls: select(type == "null");

--- a/tests/from_manual/functions.rs
+++ b/tests/from_manual/functions.rs
@@ -1,6 +1,19 @@
 use crate::test;
 
 test!(
+    abs1,
+    r#"
+    map(abs)
+    "#,
+    r#"
+    [-10, -1.1, -1e-1]
+    "#,
+    r#"
+    [10,1.1,1e-1]
+    "#
+);
+
+test!(
     length1,
     r#"
     .[] | length


### PR DESCRIPTION
This PR implements `abs/0` filter added in [jq 1.7](https://github.com/jqlang/jq/releases/tag/jq-1.7). See also https://github.com/jqlang/jq/pull/2767.