### PR TITLE
Fix implode/0 to emit replacement characters on invalid input numbers

### DIFF
--- a/src/intrinsic/string.rs
+++ b/src/intrinsic/string.rs
@@ -81,14 +81,10 @@ pub(crate) fn implode(value: Value) -> Result<Value> {
             let s = s
                 .iter()
                 .map(|c| match c {
-                    Value::Number(c) => {
-                        let c = c
-                            .to_u32()
-                            .ok_or(QueryExecutionError::InvalidNumberAsChar(*c))?;
-                        let c = char::try_from(c)
-                            .map_err(|_| QueryExecutionError::InvalidNumberAsChar(c.into()))?;
-                        Ok(c)
-                    }
+                    Value::Number(c) => Ok(c
+                        .to_u32()
+                        .and_then(|c| char::try_from(c).ok())
+                        .unwrap_or(char::REPLACEMENT_CHARACTER)),
                     _ => Err(QueryExecutionError::InvalidArgType("implode", c.clone())),
                 })
                 .collect::<Result<String>>()?;

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -62,8 +62,6 @@ pub enum QueryExecutionError {
     InvalidAsBase64(#[from] base64::DecodeError),
     #[error("Invalid as a UTF-8-encoded byte array")]
     InvalidUTF8Bytes(#[from] std::string::FromUtf8Error),
-    #[error("Invalid as a unicode scalar value `{0:}`")]
-    InvalidNumberAsChar(Number),
     #[error("utf8bytelength is applied to non-string value`{0:?}`")]
     InvalidUTF8ByteLength(Value),
     #[error("{0:?} was called invalidly with arg `{1:?}`")]

--- a/tests/from_manual/functions.rs
+++ b/tests/from_manual/functions.rs
@@ -1191,6 +1191,19 @@ test!(
 );
 
 test!(
+    implode2,
+    r#"
+    implode
+    "#,
+    r#"
+    [-1, 0, 1, 1114111, 1114112]
+    "#,
+    r#"
+    "\ufffd\u0000\u0001\udbff\udfff\ufffd"
+    "#
+);
+
+test!(
     split1,
     r#"
     split(", ")


### PR DESCRIPTION
This PR improves jq compatibility of the implode/0 filter. See https://github.com/jqlang/jq/pull/2646.