### PR TITLE
Limit string repeat result length, fix `"str" * 0` to emit ""

### DIFF
--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -38,6 +38,8 @@ pub enum QueryExecutionError {
     IncompatibleBinaryOperator(&'static str, Value, Value),
     #[error("Cannot repeat string `{0:?}` times")]
     StringRepeatByNonUSize(Number),
+    #[error("Repeat string result too long")]
+    StringRepeatTooLong,
     #[error("Cannot divide/modulo by zero")]
     DivModByZero,
     #[error("Tried to construct an object with non-string key `{0:?}`")]

--- a/tests/from_fuzz/mod.rs
+++ b/tests/from_fuzz/mod.rs
@@ -9,6 +9,16 @@ test_no_panic!(
 );
 
 test_no_panic!(
+    string_repeat_large,
+    r#"
+    "a"*1E15
+    "#,
+    r#"
+    null
+    "#
+);
+
+test_no_panic!(
     todate,
     r#"
     todate#.749;011111111111111

--- a/tests/from_manual/arithmetic.rs
+++ b/tests/from_manual/arithmetic.rs
@@ -153,11 +153,11 @@ test!(
     "abc"
     "#,
     r#"
-    null
+    ""
     "abcabcabc"
     null
     null
-    null
+    ""
     "abcabcabc"
     null
     null


### PR DESCRIPTION
This PR fixes discrepancy of `"str" * 0`. It should emit `""` instead of `null`.
Also, this PR limits the string repeat result length to max integer, so it fixes #129.
